### PR TITLE
[Feature] ignore pattern for values

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ Defines a list of property names that should be ignored by the validator.
 
 In this example, plugin would not test declaration with property name `composes`, `foo` or `bar`. As a result, no warnings for these declarations.
 
+#### ignoreValue
+
+Type: `RegExp`
+Default: `false`
+
+Defines a pattern for values that should be ignored by the validator.
+
+```json
+ "rules": {
+    "csstree/validator": {
+      "ignoreValue": "^pattern$"
+    }
+  }
+```
+
+In this example, the plugin will not report warnings for values that match the given pattern. Warnings will sill be reported for properties.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -77,6 +77,15 @@ module.exports = stylelint.createPlugin(ruleName, function(options) {
                     message = messages.uncomplete(decl.prop);
                 }
 
+                var ignoreValue = options.ignoreValue || false;
+
+                if(ignoreValue && new RegExp(ignoreValue).test(decl.value)) {
+                    if(message === messages.invalid(decl.prop) ||
+                       message === messages.uncomplete(decl.prop)) {
+                       return
+                    }
+                }
+
                 stylelint.utils.report({
                     message: message,
                     node: decl,

--- a/test/index.js
+++ b/test/index.js
@@ -74,3 +74,13 @@ css({ ignore: ['foo', 'bar'] }, function(tr) {
     tr.ok('.foo { BAR: 1 }');
     tr.notOk('.foo { baz: 1 }', 'Unknown property `baz`');
 });
+
+css({ ignoreValue: "^patternToIgnore$", ignore: ['bar'] }, function(tr) {
+    tr.ok('.foo { color: red }');
+    tr.ok('.foo { color: #fff }');
+    tr.ok('.foo { color: patternToIgnore }');
+    tr.ok('.foo { bar: notMatchingPattern }');
+    tr.notOk('.foo { color: notMatchingPattern }', messages.invalid('color'));
+    tr.notOk('.foo { foo: patternToIgnore }', 'Unknown property `foo`');
+    tr.notOk('.foo { foo: notMatchingPattern }', 'Unknown property `foo`');
+})


### PR DESCRIPTION
This introduces a new option: ```ignoreValue``` which takes a Regular Expression and prevents Invalid/Parse warnings for values that match the pattern. Property warnings will still be reported.

It should help with issues like #10 and #11. Another use case is one I came across when building [stylelint-processor-glamorous](https://github.com/zabute/stylelint-processor-glamorous): The processor replaces javascript expressions with a placeholder value before flushing the css to stylelint. This causes spurious Invalid value warnings. I thought about taking care of it within the processor but looking at #10 & #11, I thought it would be best for this validator to handle it.


**PR includes:**
- [x] Documentation
- [x]  Tests