### PR TITLE
Updated peer dependencies of stylelint version from (>=7.0.0 <14.0.0) to (>=7.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "css-tree": "^1.1.2"
   },
   "peerDependencies": {
-    "stylelint": ">=7.0.0 <14.0.0"
+    "stylelint": ">=7.0.0"
   },
   "devDependencies": {
     "mocha": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-csstree-validator",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Stylelint plugin to validate CSS syntax",
   "repository": "csstree/stylelint-validator",
   "author": "Roman Dvornov <rdvornov@gmail.com>",


### PR DESCRIPTION
Removed <14.0.0 option, so stylelint-csstree-validator can support latest version of Stylelint releases.