### PR TITLE
Update csstree to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^2.0.1"
+        "css-tree": "^2.2.1"
       },
       "devDependencies": {
         "c8": "^7.10.0",
@@ -625,15 +625,15 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.0.1.tgz",
-      "integrity": "sha512-rY9547sbMV6T7uD7ZI+b0ncoH7uA4DVil6TLHewrAai28DMDVFxwu0yK/e4wMk4DlP/NFpkpWYWtkZwbpSdpaw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "dependencies": {
-        "mdn-data": "2.0.23",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.0 || >=15.0.0",
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
         "npm": ">=7.0.0"
       }
     },
@@ -1748,9 +1748,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.23.tgz",
-      "integrity": "sha512-IonVb7pfla2U4zW8rc7XGrtgq11BvYeCxWN8HS+KFBnLDE7XDK9AAMVhRuG6fj9BBsjc69Fqsp6WEActEdNTDQ=="
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/meow": {
       "version": "9.0.0",
@@ -2676,19 +2676,10 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
       "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3706,12 +3697,12 @@
       }
     },
     "css-tree": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.0.1.tgz",
-      "integrity": "sha512-rY9547sbMV6T7uD7ZI+b0ncoH7uA4DVil6TLHewrAai28DMDVFxwu0yK/e4wMk4DlP/NFpkpWYWtkZwbpSdpaw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "requires": {
-        "mdn-data": "2.0.23",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
       }
     },
     "cssesc": {
@@ -4548,9 +4539,9 @@
       "dev": true
     },
     "mdn-data": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.23.tgz",
-      "integrity": "sha512-IonVb7pfla2U4zW8rc7XGrtgq11BvYeCxWN8HS+KFBnLDE7XDK9AAMVhRuG6fj9BBsjc69Fqsp6WEActEdNTDQ=="
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "meow": {
       "version": "9.0.0",
@@ -5194,16 +5185,10 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
     "source-map-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
-      "dev": true
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "npm": ">=7.0.0"
   },
   "dependencies": {
-    "css-tree": "^2.0.1"
+    "css-tree": "^2.2.1"
   },
   "peerDependencies": {
     "stylelint": ">=7.0.0 <15.0.0"


### PR DESCRIPTION
I recently [filed a bug](https://github.com/csstree/stylelint-validator/issues/47) asking to support use of `attr` for `content`. This was supported already in `csstree` in version [`2.2.0`](https://github.com/csstree/csstree/releases/tag/v2.2.0). This PR is to update the `csstree` dependency in `stylelint-csstree-validator` to `2.2.1` which is the latest version at the time of writing.

@lahmatiy please let me know if I should bump the `stylelint-css-tree-validator` version as well.